### PR TITLE
Use HomeDir()

### DIFF
--- a/inboxfewer.go
+++ b/inboxfewer.go
@@ -67,7 +67,7 @@ func (c *FewerClient) ForeachThread(q string, fn func(*gmail.Thread) error) erro
 }
 
 func readGithubConfig() {
-	file := filepath.Join(os.Getenv("HOME"), "keys", "github-inboxfewer.token")
+	file := filepath.Join(HomeDir(), "keys", "github-inboxfewer.token")
 	slurp, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Outside HomeDir(), os.Getenv("HOME") is used to get the current user
director even though HomeDir() supports Windows and Unix-like systems.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bradfitz/inboxfewer/2)

<!-- Reviewable:end -->
